### PR TITLE
Fix dockerfile by adding gdal env var and use 3.6 tag for python.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python
+FROM python:3.6
+
+# Fiona requires Python versions 3.6+ and GDAL version 1.11-3.0 with GDAL_VERSION specified
+ENV GDAL_VERSION=3.0
 
 RUN apt-get -y update;  apt -y install software-properties-common 
 RUN add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable


### PR DESCRIPTION
This addresses #4.

When building an image I got an error:

```
ERROR: A GDAL API version must be specified. 
Provide a path to gdal-config using a GDAL_CONFIG environment variable 
or use a GDAL_VERSION environment variable.
```

After specifying this env var in the `Dockerfile`, I then got another error:
```
mtrand.o.d failed with exit status 1
```

I then made sure the base python image had a version specified to `3.6` via a tag. This cleared up that error since I assume it was just using the latest tag with python `3.7` or higher and those higher versions of python get errors like [these](https://github.com/numpy/numpy/issues/9391).