### PR TITLE
Use use proper input datetime format and fix crs warnings

### DIFF
--- a/download_census_tracts.py
+++ b/download_census_tracts.py
@@ -31,21 +31,21 @@ acs = cenpy.products.ACS(2017)
 
 print('Downloading New Orleans')
 new_orleans = acs.from_place('New Orleans, LA',variables=list(columns.values()),level='tract')
-new_orleans.to_crs({"init":'epsg:4326'}).to_file("data/raw/NewOrleans/tracts.geojson")
+new_orleans.to_crs('epsg:4326').to_file("data/raw/NewOrleans/tracts.geojson")
 
 print('Downloading South Carolina')
 charleston = acs.from_state('South Carolina',variables=list(columns.values()),level='tract')
-charleston.to_crs({"init":'epsg:4326'}).to_file("data/raw/Charleston/tracts.geojson")
+charleston.to_crs('epsg:4326').to_file("data/raw/Charleston/tracts.geojson")
 
 print('Downloading Seattle')
 seattle  = acs.from_place('Seattle, WA', variables=list(columns.values()),level='tract',place_type='Incorporated Place')
-seattle.to_crs({"init":'epsg:4326'}).to_file('data/raw/Seattle/tracts.geojson')
+seattle.to_crs('epsg:4326').to_file('data/raw/Seattle/tracts.geojson')
 
 print('Downloading Detroit')
 detroit = acs.from_place('Detroit, MI',variables=list(columns.values()),level='tract',place_type='Incorporated Place')
-detroit.to_crs({"init":'epsg:4326'}).to_file("data/raw/Detroit/tracts.geojson")
+detroit.to_crs('epsg:4326').to_file("data/raw/Detroit/tracts.geojson")
 
 print('Downloading Dallas')
 dallas = acs.from_place('Dallas, MI',variables=list(columns.values()),level='tract', place_type='Incorporated Place')
-dallas.to_crs({"init":'epsg:4326'}).to_file("data/raw/Detroit/tracts.geojson")
+dallas.to_crs('epsg:4326').to_file("data/raw/Detroit/tracts.geojson")
 

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -15,11 +15,16 @@ seattle = Seattle()
 detroit = Detroit()
 charleston = Charleston()
 
-new_orleans.process_data()
 dallas.process_data()
-detroit.process_data()
-charleston.process_data()
-seattle.process_data()
+# detroit.process_data()
+# charleston.process_data()
+# seattle.process_data()
+
+import time
+start_time = time.perf_counter()
+new_orleans.process_data()
+end_time = time.perf_counter()
+print(f"New Orleans processing took {end_time - start_time:0.4f} seconds")
 
 
 new_orleans.clean_data().to_csv('data/processed/NewOrleans/NewOrleans.csv', index=False)

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -15,7 +15,7 @@ seattle = Seattle()
 detroit = Detroit()
 charleston = Charleston()
 
-new_orleans.process_data()	
+new_orleans.process_data()
 dallas.process_data()
 detroit.process_data()
 charleston.process_data()

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -15,16 +15,11 @@ seattle = Seattle()
 detroit = Detroit()
 charleston = Charleston()
 
+new_orleans.process_data()	
 dallas.process_data()
-# detroit.process_data()
-# charleston.process_data()
-# seattle.process_data()
-
-import time
-start_time = time.perf_counter()
-new_orleans.process_data()
-end_time = time.perf_counter()
-print(f"New Orleans processing took {end_time - start_time:0.4f} seconds")
+detroit.process_data()
+charleston.process_data()
+seattle.process_data()
 
 
 new_orleans.clean_data().to_csv('data/processed/NewOrleans/NewOrleans.csv', index=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 Pygments==2.5.2
 pyparsing==2.4.6
-pyproj==2.4.2.post1
+pyproj==2.6.1.post1
 pyrsistent==0.15.7
 python-dateutil==2.8.1
 python-dotenv==0.11.0

--- a/src/cities/city.py
+++ b/src/cities/city.py
@@ -42,7 +42,7 @@ class City:
     COLUMN_TRANSFORMS = {}
     
     # Basic data format for dates in the dataset
-    DATE_FORMAT = "%m/%d/%Y %H:%M:%S %p"
+    DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
     
     
     # What columns should map to the variables we need in the final dataset?
@@ -67,7 +67,7 @@ class City:
     ENCODING = 'utf-8'
     
     # Input CRS for the call data geometries assumed 4326 (lng lat)
-    INPUT_CRS =  {'init':'EPSG:4324'}
+    INPUT_CRS =  'EPSG:4324'
     
     # Columns if any to remap the inputs to lat lng
     GEO_COLUMNS_REMAP= {} 
@@ -303,7 +303,7 @@ class City:
             data = gpd.read_file(str(raw_data_path / file['path']))
             data = data[[self.BEATS_IDS_GEOMETRY,'geometry']]
             
-            data = data.to_crs({'init':'epsg:4326'})
+            data = data.to_crs('epsg:4326')
             data = Geo.area_weighted_(data,tracts,beat_id=self.BEATS_IDS_GEOMETRY)
             for year in range(file['start_year'],file['end_year']):
                 data = data.assign(year=year)
@@ -311,7 +311,7 @@ class City:
                     data)
         all_beats_years = pd.concat(all_beats_years)
 
-        return gpd.GeoDataFrame(all_beats_years,geometry='geometry',crs={'init':"epsg:4326"})
+        return gpd.GeoDataFrame(all_beats_years,geometry='geometry',crs="epsg:4326")
     
     def assign_beats(self,df=None):
         if(type(df)==type(None)):
@@ -321,7 +321,7 @@ class City:
         res = df.merge(beats_data, left_on=['beat','year'],
                              right_on=['beat','year'])
 
-        return gpd.GeoDataFrame(res, geometry='geometry', crs={'init':'epsg:4326'})    
+        return gpd.GeoDataFrame(res, geometry='geometry', crs='epsg:4326')    
        
         
     def assign_geometry(self,df=None):
@@ -336,7 +336,7 @@ class City:
                       .set_index('GEOID')
                       .assign(geometry = self.load_tracts().set_index('GEOID').geometry), 
                     geometry='geometry', 
-                    crs={'init':'epsg:4326'}
+                    crs='epsg:4326'
                  )
     
     def norm_by(self,df,norm_by=None):
@@ -358,7 +358,7 @@ class City:
             return df_copy
         if(norm_by=='area'):
             df_copy = df.copy()
-            df_copy[columns] = df_copy[columns].div( gpd.GeoDataFrame(df,geometry='geometry', crs={'init':'epsg:4326'}).to_crs({'init':'epsg:3366'}).geometry.area, axis=0)
+            df_copy[columns] = df_copy[columns].div( gpd.GeoDataFrame(df,geometry='geometry', crs='epsg:4326').to_crs('epsg:3366').geometry.area, axis=0)
             return df_copy 
         
         
@@ -505,7 +505,7 @@ class City:
                       .set_index('GEOID')
                       .assign(geometry = self.load_tracts().set_index('GEOID').geometry), 
                     geometry='geometry', 
-                    crs={'init':'epsg:4326'}
+                    crs='epsg:4326'
                  )
     
     def norm_by(self,df,norm_by=None):
@@ -528,7 +528,7 @@ class City:
             return df_copy
         if(norm_by=='area'):
             df_copy = df.copy()
-            df_copy[columns] = df_copy[columns].div( gpd.GeoDataFrame(df,geometry='geometry', crs={'init':'epsg:4326'}).to_crs({'init':'epsg:3366'}).geometry.area, axis=0)
+            df_copy[columns] = df_copy[columns].div( gpd.GeoDataFrame(df,geometry='geometry', crs='epsg:4326').to_crs('epsg:3366').geometry.area, axis=0)
             return df_copy 
         
         

--- a/src/cities/dallas.py
+++ b/src/cities/dallas.py
@@ -36,7 +36,7 @@ class Dallas(City):
     
     END_TIME_COL = 'Call Cleared Date Time'
         
-    INPUT_CRS =  {'init':'EPSG:32138'}
+    INPUT_CRS =  'EPSG:32138'
     
     
     ENFORCEMENT_VARIABLES=['Arrest Issued']

--- a/src/cities/detroit.py
+++ b/src/cities/detroit.py
@@ -7,7 +7,7 @@ class Detroit(City):
     
     BASE_NAME = 'Detroit'
     DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
-#    DATE_FORMAT = '%m/%d/%Y %H:%M:%S %p'
+#    DATE_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
     DATA_URLS = {
         'all': "https://opendata.arcgis.com/datasets/2dab2f70653f4bb8b4f2b51619ec8329_0.csv"
@@ -49,7 +49,7 @@ class Detroit(City):
     
     RESPONSE_TIME_FACTOR = 60
     RESPONSE_TIME_COLUMN = 'response_time'
-#     INPUT_CRS =  {'init':'EPSG:26971'}
+#     INPUT_CRS =  'EPSG:26971'
 
     GEO_COLUMNS_REMAP = { 'latitude': 'lat' , 'longitude' : 'lng' }
 #     GEO_UNIT_CONVERSION =  0.3048  #Feet to meters

--- a/src/cities/new_orleans.py
+++ b/src/cities/new_orleans.py
@@ -2,7 +2,7 @@ from .city import City
 
 class NewOrleans(City):
     BASE_NAME = 'NewOrleans'
-    DATE_FORMAT = '%m/%d/%Y %H:%M:%S %p'
+    DATE_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
     
     COLUMN_TRANSFORMS = {
         'TimeArrive' : 'date_time',
@@ -61,7 +61,7 @@ class NewOrleans(City):
     ## New Orleans data is in state plane coordinates and in feet 
     # rather than meters, this should fix that
     
-    INPUT_CRS =  {'init':'EPSG:26982'}
+    INPUT_CRS =  'EPSG:26982'
 
     GEO_COLUMNS_REMAP = { 'MapY': 'lat' , 'MapX' : 'lng' }
     GEO_UNIT_CONVERSION =  0.3048  #Feet to meters

--- a/src/cities/seattle.py
+++ b/src/cities/seattle.py
@@ -27,7 +27,7 @@ class Seattle(City):
     }
 
     DATE_FORMAT = {
-        'Original Time Queued' : '%m/%d/%Y %H:%M:%S %p',
+        'Original Time Queued' : '%Y-%m-%d %H:%M:%S.%f',
         'Arrived Time' : '%b %d %Y %H:%M:%S:000%p'
     }
 

--- a/src/data/download_charleston.py
+++ b/src/data/download_charleston.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 BASE_NAME = 'Charleston'
 
-DATE_FORMAT = '%m/%d/%Y %H:%M:%S %p'
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 COLUMN_TRANSFORMS = {
 #     'TimeArrive' : 'date_time',
 #     'TimeCreate' : 'date_time',

--- a/src/data/download_detroit.py
+++ b/src/data/download_detroit.py
@@ -13,7 +13,7 @@ DATA_URLS = {
     'all': "https://data.detroitmi.gov/api/views/wgv9-drfc/rows.csv?accessType=DOWNLOAD"
 }
 
-DATE_FORMAT = '%m/%d/%Y %H:%M:%S %p'
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 COLUMN_TRANSFORMS = {
     'Call Time' : 'date_time'

--- a/src/data/download_new_orleans.py
+++ b/src/data/download_new_orleans.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 BASE_NAME = 'NewOrleans'
 
-DATE_FORMAT = '%m/%d/%Y %H:%M:%S %p'
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 COLUMN_TRANSFORMS = {
     'TimeArrive' : 'date_time',
     'TimeCreate' : 'date_time',

--- a/src/data/download_seattle.py
+++ b/src/data/download_seattle.py
@@ -20,7 +20,7 @@ DATA_URLS = {
 }
 
 DATE_FORMAT = {
-    'Original Time Queued' : '%m/%d/%Y %H:%M:%S %p',
+    'Original Time Queued' : '%Y-%m-%d %H:%M:%S.%f',
     'Arrived Time' : '%b %d %Y %H:%M:%S:000%p'
 }
 

--- a/src/features/geo.py
+++ b/src/features/geo.py
@@ -21,7 +21,7 @@ CENSUS_VARIABLES = {
      
 }
 INPUT_CRS = {
-    'NewOrleans': {'init':'EPSG:26982'}
+    'NewOrleans': 'EPSG:26982'
 }
 
 GEO_COLUMNS_REMAP= {

--- a/src/features/geo.py
+++ b/src/features/geo.py
@@ -52,7 +52,7 @@ def assign_point_to_census_tract(city, chunk_size=10000):
 def assign_point_to_beat(city, chunk_size=10000):
     print('Joining to tracts')
     result = []
-    beats = city.load_beats().to_crs({'init':'epsg:4326'})
+    beats = city.load_beats().to_crs('epsg:4326')
     calls  = city.processed_data
     for index, chunk in tqdm(calls.groupby(np.arange(calls.shape[0])//chunk_size)):
         result.append( gpd.sjoin(chunk, beats[[city.BEATS_IDS_GEOMETRY, 'geometry']], how='left', op='within'))
@@ -67,7 +67,7 @@ def convert_geo_units(city):
 def generate_points_city(city):
     print('Generating point geometries')
     crs = city.INPUT_CRS
-    lat_lng_crs = {'init':"epsg:4326"}
+    lat_lng_crs = "epsg:4326"
     calls = city.processed_data
     return gpd.GeoDataFrame(calls, 
                            geometry= calls.progress_apply(
@@ -89,15 +89,15 @@ def area_weighted_overlap(beats,tracts,beat_id='beat'):
     # Calculate the intersection shapes between any beats and tracts that overlap
     beats =beats.copy().rename(columns={beat_id:'beat'})
     overlaps  = gpd.overlay(
-                    tracts.to_crs({'init':'epsg:4326'}), 
-                    beats.to_crs({'init':'epsg:4326'})
+                    tracts.to_crs('epsg:4326'), 
+                    beats.to_crs('epsg:4326')
                 )
     # Calculate the area of those overlapping regions
-    overlaps = overlaps.assign(overlap_area = overlaps.to_crs({'init':'epsg:3366'}).area)
+    overlaps = overlaps.assign(overlap_area = overlaps.to_crs('epsg:3366').area)
     # Join back to the census data and caclulate the area of the tracts
     
     overlaps = overlaps.merge(
-        tracts.assign(tract_area = tracts.to_crs({'init':'epsg:3366'}).area)
+        tracts.assign(tract_area = tracts.to_crs('epsg:3366').area)
         [['GEOID', 'tract_area']],
         on="GEOID",
         how='left'

--- a/src/visualization/visualize.py
+++ b/src/visualization/visualize.py
@@ -18,7 +18,7 @@ demographics=[
     'pc_hispanic'
 ]
 
-map_crs= {'init':'epsg:3857'}
+map_crs= 'epsg:3857'
         
 def map_self_initiated(city, ax=None, call_type=None, norm_by=None, year=None, vmin=None, vmax=None, scheme=None):
     if(not ax):


### PR DESCRIPTION
This PR captures 2 issues we had when running the data processing step on the cities:

1. I got warnings related to pyproj deprecating a syntax that we were currently using: `+init=<auth>:<auth_code> syntax is deprecated and will be removed in future versions of PROJ`. To fix this, I used their recommended syntax of `<auth>:<auth_code>`. See [here for source docs on this deprecation](https://pyproj4.github.io/pyproj/stable/gotchas.html#init-auth-auth-code-should-be-replaced-with-auth-auth-code).  (And this warning was even on the original pyproj dependency that was set)
2. I got errors related to malformed time formats. To fix this, I updated the cities datetime configurations like: `DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'`

Additionally, I updated the pyproj dependency to `pyproj==2.6.1.post1`.

**One question** - I saw that `DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'` was actually already in the repo, but commented out. Does this mean that the raw input data format changed over the past few months?