### PR TITLE
Fixed the date format for date fields in the city of Seattle dataset

### DIFF
--- a/src/cities/seattle.py
+++ b/src/cities/seattle.py
@@ -27,8 +27,8 @@ class Seattle(City):
     }
 
     DATE_FORMAT = {
-        'Original Time Queued' : '%Y-%m-%d %H:%M:%S.%f',
-        'Arrived Time' : '%b %d %Y %H:%M:%S:000%p'
+        'Original Time Queued' : '%m/%d/%Y %I:%M:%S %p',
+        'Arrived Time' : '%m/%d/%Y %I:%M:%S %p'
     }
 
     COLUMN_TRANSFORMS = {


### PR DESCRIPTION
Fixes #27

Changed the Date format of the city of Seattle dataset from '%Y-%m-%d %H:%M:%S.%f' to '%m/%d/%Y %I:%M:%S %p'.